### PR TITLE
STYLE: Fix CMake warning setting CMP0048 to NEW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 2.8.9)
 
+if(POLICY CMP0048)
+  cmake_policy(SET CMP0048 NEW) # CMake 3.0.0
+endif()
+
 project(SimpleFilters)
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION

This commit will avoid the following warning:

```
//-----------------------------------------
  Policy CMP0048 is not set: project() command manages VERSION variables.
  Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The following variable(s) would be set to empty:

    PROJECT_VERSION
    PROJECT_VERSION_MAJOR
    PROJECT_VERSION_MINOR
    PROJECT_VERSION_PATCH
//-----------------------------------------
```