### PR TITLE
PERF: Speedup module loading delaying SimpleITK import

### DIFF
--- a/SimpleFilters/SimpleFilters.py
+++ b/SimpleFilters/SimpleFilters.py
@@ -1,7 +1,5 @@
 import os,sys
 import unittest
-import SimpleITK as sitk
-import sitkUtils
 from __main__ import vtk, qt, ctk, slicer
 from glob import glob
 import json
@@ -10,6 +8,11 @@ import re
 import threading
 import Queue
 from time import sleep
+
+# To avoid the overhead of importing SimpleITK during application
+# startup, the import of SimpleITK is delayed until it is needed.
+sitk = None
+sitkUtils = None
 
 #
 # SimpleFilters
@@ -66,6 +69,14 @@ The developers would like to thank the support of the Slicer Community, the Insi
 
 class SimpleFiltersWidget:
   def __init__(self, parent = None):
+
+    # To avoid the overhead of importing SimpleITK during application
+    # startup, the import of SimpleITK is delayed until it is needed.
+    global sitk
+    import SimpleITK as sitk
+    global sitkUtils
+    import sitkUtils
+
     if not parent:
       self.parent = slicer.qMRMLWidget()
       self.parent.setLayout(qt.QVBoxLayout())


### PR DESCRIPTION
Improve the loading time of the SimpleFilters module
by ~50%  (2.6s -> 1.2s, warm cache)

Results have been gathered on Ubuntu 15.10 on a workstation with the
following specs: 64GB / M.2 PCIe NVMe SSD / Quad Core 3.80GHz

The following command has been used to measure the time:

```
~/Projects/Slicer/Applications/SlicerApp/Testing/Python/MeasureStartupTimes.py -n 5 --modules-to-load SimpleFilters ./Slicer
```