### PR TITLE
BUG: Fix unknown SimpleITK class messages when missing ITK Modules

### DIFF
--- a/SimpleFilters/SimpleFilters.py
+++ b/SimpleFilters/SimpleFilters.py
@@ -100,8 +100,9 @@ class SimpleFiltersWidget:
         if j["name"] in dir(sitk):
           self.jsonFilters.append(j)
         else:
-          import sys
-          sys.stderr.write("Unknown SimpleITK class \"{0}\".\n".format(j["name"]))
+          if j["itk_module"] in sitk.Version().ITKModulesEnabled():
+            import sys
+            sys.stderr.write("Unknown SimpleITK class \"{0}\".\n".format(j["name"]))
       except Exception as e:
         import sys
         sys.stderr.write("Error while reading \"{0}\". Exception: {1}\n".format(fname, e))


### PR DESCRIPTION
This closes #11.

"Unknown SimpleITK class" messages will only be written to standard error if its corresponding ITKModule is enabled.