### PR TITLE
BUG: Fix calling disconnect on destroyed object

### DIFF
--- a/SimpleFilters/SimpleFilters.py
+++ b/SimpleFilters/SimpleFilters.py
@@ -551,8 +551,6 @@ class FilterParameters(object):
     self.outputLabelMapBox = None
 
   def __del__(self):
-    for widget, sig in self.widgetConnections:
-      widget.disconnect(sig)
     self.widgetConnections = []
     self.widgets = []
 


### PR DESCRIPTION
@blowekamp @jcfr This fixes the following exception error observed on close of Slicer 4.10 after having opened the SimpleFilters module:
```terminal
Exception ValueError: "Trying to call 'disconnect' on a destroyed qMRMLNodeComboBox object" in <bound method FilterParameters.__del__ of <SimpleFilters.FilterParameters object at 0x0000000015ABD2E8>> ignored
```

The code I'm removing was originally introduced as part of a fix for #10.  I'm only reverting this one part of that commit because I checked and the rest of it is still needed for that fix in that issue.