### PR TITLE
ENH: Support for Python3

### DIFF
--- a/SimpleFilters/SimpleFilters.py
+++ b/SimpleFilters/SimpleFilters.py
@@ -96,8 +96,7 @@ class SimpleFiltersWidget(object):
       self.parent.show()
 
     jsonFiles = glob(SimpleFilters.JSON_DIR+"*.json")
-    cmp = lambda x, y: (x > y) - (x < y)
-    jsonFiles.sort(cmp=lambda x,y: cmp(os.path.basename(x), os.path.basename(y)))
+    jsonFiles.sort(key=lambda x: os.path.basename(x))
 
     self.jsonFilters = []
 

--- a/SimpleFilters/Testing/Python/SimpleFiltersModuleTest.py
+++ b/SimpleFilters/Testing/Python/SimpleFiltersModuleTest.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import unittest
 import qt
 import slicer
@@ -37,7 +38,7 @@ class SimpleFiltersTest(unittest.TestCase):
     m = slicer.util.mainWindow()
     m.moduleSelector().selectModule('SimpleFilters')
 
-    print "testing my test...."
+    print("testing my test....")
 
     testWidget = slicer.modules.SimpleFiltersWidget
 

--- a/Utilities/JSONGenerateWikiDocs.py
+++ b/Utilities/JSONGenerateWikiDocs.py
@@ -9,6 +9,7 @@
 # Usage: Utilities/JSONGenerateWikiDocs.py SimpleFilters/Resources/json/*.json
 #
 
+from __future__ import print_function
 import json
 import sys
 try:
@@ -19,11 +20,11 @@ except ImportError:
 # This script takes one argument the name of a json file.
 #
 
-print """{| border="1" style="border-collapse:collapse;"
+print("""{| border="1" style="border-collapse:collapse;"
 |-
 ! Filter Name
 ! Brief Description
-! ITK Class"""
+! ITK Class""")
 
 entryFormat = "|-\n! {0}\n! {1}\n! [http://www.itk.org/Doxygen/html/classitk_1_1{2}.html {2}]"
 for fname in sys.argv[1:]:
@@ -52,6 +53,6 @@ for fname in sys.argv[1:]:
     else:
         jsonITK = jsonName
 
-    print entryFormat.format(jsonName, jsonBrief, jsonITK)
+    print(entryFormat.format(jsonName, jsonBrief, jsonITK))
 
-print "|}"
+print("|}")


### PR DESCRIPTION
Updated code is expected to work with both Python2 and Python3

Slicer migration guide describes how to update the code. See https://www.slicer.org/wiki/Documentation/Nightly/Developers/Tutorials/MigrationGuide/SlicerExtension#Slicer_5.0:_Python2_to_Python3

This commit was crafted by:

- installing future

```
  Slicer_DIR=/path/to/Slicer-SuperBuild/Slicer-build
  ${Slicer_DIR}/../python-install/bin/PythonSlicer -m pip install
future
```

- applying all fixes

```
  for f in `find ./ -name "*.py"`; do \
    ${Slicer_DIR}/../python-install/bin/PythonSlicer \
      --launch futurize -w $f; \
  done
```

- reviewing the changes and updating as needed.