### PR TITLE
BUG: Fix python3 incompatibilities for file and exec calls

### DIFF
--- a/SimpleFilters/SimpleFilters.py
+++ b/SimpleFilters/SimpleFilters.py
@@ -102,7 +102,7 @@ class SimpleFiltersWidget(object):
 
     for fname in jsonFiles:
       try:
-        fp = file(fname, "r")
+        fp = open(fname, "r")
         j = json.load(fp,object_pairs_hook=OrderedDict)
         if j["name"] in dir(sitk):
           self.jsonFilters.append(j)
@@ -907,7 +907,7 @@ class FilterParameters(object):
 
       # check if current item is default, set if it is
       exec('itemValue='+v, globals(), locals())
-      if itemValue  == default:
+      if itemValue  == locals()["default"]:
         w.setCurrentIndex(w.count-1)
 
     w.connect("currentIndexChanged(int)", lambda selectorIndex,n=name,selector=w:self.onEnumChanged(n,selectorIndex,selector))
@@ -938,7 +938,7 @@ class FilterParameters(object):
     self.widgetConnections.append((w, "coordinatesChanged(double*)"))
 
     exec('default = self.filter.Get{0}()'.format(name), globals(), locals())
-    w.coordinates = ",".join(str(x) for x in default)
+    w.coordinates = ",".join(str(x) for x in locals()["default"])
     return w
 
   def createIntWidget(self,name,type="int"):
@@ -960,7 +960,7 @@ class FilterParameters(object):
       w.setRange(-2147483648,2147483647)
 
     exec('default = self.filter.Get{0}()'.format(name), globals(), locals())
-    w.setValue(int(default))
+    w.setValue(int(locals()["default"]))
     w.connect("valueChanged(int)", lambda val,name=name:self.onScalarChanged(name,val))
     self.widgetConnections.append((w, "valueChanged(int)"))
     return w
@@ -970,7 +970,7 @@ class FilterParameters(object):
     w = qt.QCheckBox()
     self.widgets.append(w)
 
-    w.setChecked(default)
+    w.setChecked(locals()["default"])
 
     w.connect("stateChanged(int)", lambda val,name=name:self.onScalarChanged(name,bool(val)))
     self.widgetConnections.append((w, "stateChanged(int)"))
@@ -985,7 +985,7 @@ class FilterParameters(object):
     w.setRange(-3.40282e+038, 3.40282e+038)
     w.decimals = 5
 
-    w.setValue(default)
+    w.setValue(locals()["default"])
     w.connect("valueChanged(double)", lambda val,name=name:self.onScalarChanged(name,val))
     self.widgetConnections.append((w, "valueChanged(double)"))
 


### PR DESCRIPTION
This should close #17.

@blowekamp Please review and test using some filters.  The changes made related to the `exec` call differences between python2 and python3 were made based on reading this stackoverflow https://stackoverflow.com/questions/15086040/behavior-of-exec-function-in-python-2-and-python-3.  The code here is a little out of the ordinary and I'm not super familiar with the exec call.