### PR TITLE
BUG: Fix overflow errors due to uint64 and int64 values

### DIFF
--- a/SimpleFilters/SimpleFilters.py
+++ b/SimpleFilters/SimpleFilters.py
@@ -815,9 +815,10 @@ class FilterParameters(object):
       elif t in ["uint8_t", "int8_t",
                "uint16_t", "int16_t",
                "uint32_t", "int32_t",
-               "uint64_t", "int64_t",
                "unsigned int", "int"]:
         w = self.createIntWidget(member["name"],t)
+      elif t in ["uint64_t", "int64_t"]:
+        w = self.createLargeIntWidget(member["name"])
       else:
         import sys
         sys.stderr.write("Unknown member \"{0}\" of type \"{1}\"\n".format(member["name"],member["type"]))
@@ -958,14 +959,24 @@ class FilterParameters(object):
       w.setRange(0,65535)
     elif type=="int16_t":
       w.setRange(-32678,32767)
-    elif type=="uint32_t" or  type=="uint64_t" or type=="unsigned int":
+    elif type=="uint32_t" or type=="unsigned int":
       w.setRange(0,2147483647)
-    elif type=="int32_t" or  type=="uint64_t" or type=="int":
+    elif type=="int32_t" or type=="int":
       w.setRange(-2147483648,2147483647)
 
     w.setValue(int(self._getParameterValue(name)))
     w.connect("valueChanged(int)", lambda val,name=name:self.onScalarChanged(name,val))
     self.widgetConnections.append((w, "valueChanged(int)"))
+    return w
+
+  def createLargeIntWidget(self,name):
+    w = qt.QLineEdit()
+    self.widgets.append(w)
+    validator = qt.QRegExpValidator(qt.QRegExp(r'[0-9-]{0,20}'), w)
+    w.setValidator(validator)
+    w.setText(self._getParameterValue(name))
+    w.connect("textChanged(QString)", lambda val,name=name:self.onScalarChanged(name,int(val)))
+    self.widgetConnections.append((w, "textChanged(QString)"))
     return w
 
   def createBoolWidget(self,name):


### PR DESCRIPTION
This fixes a long failing test as seen in http://slicer.cdash.org/testDetails.php?test=9823818&build=1743836 due to a large uint64 unable to being set to a QSpinBox or QDoubleSpinBox widget. I've made changes to display this value in a QLineEdit that only allows numbers as a workaround.

I can issue a PR to the Slicer repo to update the git hash after this is merged.

```log
1>------ Build started: Project: RUN_TESTS, Configuration: Release x64 ------
1>Test project C:/D/SimpleFilters-bin
1>    Start 1: py_nomainwindow_qSlicerSimpleFiltersModuleGenericTest
1>1/2 Test #1: py_nomainwindow_qSlicerSimpleFiltersModuleGenericTest ...   Passed    2.38 sec
1>    Start 2: py_SimpleFiltersModuleTest
1>2/2 Test #2: py_SimpleFiltersModuleTest ..............................   Passed   37.32 sec
1>
1>100% tests passed, 0 tests failed out of 2
1>
1>Total Test time (real) =  39.71 sec
========== Build: 1 succeeded, 0 failed, 1 up-to-date, 0 skipped ==========
```