### PR TITLE
BUG: Fix Qt6 incompatibility due to removed QRegExp

### DIFF
--- a/SimpleFilters/SimpleFilters.py
+++ b/SimpleFilters/SimpleFilters.py
@@ -985,7 +985,7 @@ class FilterParameters:
   def createLargeIntWidget(self,name):
     w = qt.QLineEdit()
     self.widgets.append(w)
-    validator = qt.QRegExpValidator(qt.QRegExp(r'[0-9-]{0,20}'), w)
+    validator = qt.QRegularExpressionValidator(qt.QRegularExpression(r'^[0-9-]{0,20}$'), w)
     w.setValidator(validator)
     w.setText(self._getParameterValue(name))
     w.connect("textChanged(QString)", lambda val,name=name:self.onScalarChanged(name,int(val)))


### PR DESCRIPTION
This is a follow-up to Qt6 compatibility fixes in #28.

QRegularExpression is available for use in both Qt5 and Qt6.

cc: @lassoan @jcfr 